### PR TITLE
Remove unecessary use of convertHash to resolve compatability issue with Lix

### DIFF
--- a/src/lib/build-firefox-xpi-addon.nix
+++ b/src/lib/build-firefox-xpi-addon.nix
@@ -19,11 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     inherit url;
-    sha256 = builtins.convertHash {
-      inherit hash;
-      toHashFormat = "sri";
-      hashAlgo = "sha256";
-    };
+    sha256 = hash;
   };
 
   preferLocalBuild = true;


### PR DESCRIPTION
It is unneeded as fetchurl natively supports sha256:hex Additionally this solves a compatability issue with Lix due to it missing convertHash.